### PR TITLE
Remove babel dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "css-loader"
   ],
   "dependencies": {
-    "babel": "^6.3.26",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "babel-traverse": "^6.3.26",


### PR DESCRIPTION
The babel dependency is unneeded with Babel 6 and causes the following error when running ````npm i````:

````
The CLI has been moved into the package `babel-cli`. See http://babeljs.io/docs/usage/cli/
````