### PR TITLE
copy warning from babel-plugin-css-modules-transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ build it with `npm run example-build` and execute with `node build/myCoolLibrary
 
 - [minimal-example-standalone-repo](https://github.com/istarkov/minimal-example-for-babel-plugin-webpack-loaders)
 
+## Warning
+
+**Do not run this plugin as part of webpack frontend configuration. This plugin is intended only for backend compilation.**
+
+
 # How it works
 
 Look at [minimal-example](https://github.com/istarkov/minimal-example-for-babel-plugin-webpack-loaders)


### PR DESCRIPTION
My understanding is that this plugin is only meant to be used for the server side build.

There seems to be people getting thinking this would be used for a client side build. They're getting confused and wondering why you would do this for a client side build :smile:

I copied this warning from https://github.com/michalkvasnicak/babel-plugin-css-modules-transform to try to clear that up...