### PR TITLE
Appveyor

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
+/.*/
+/.*
 .DS_Store
 *.log
 src

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ test
 examples
 examples_webpack_configs
 build
+/appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ branches:
   - master
 
 environment:
-  nodejs_version: '5.4.1'
+  nodejs_version: '5.2.0'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+branches:
+  only:
+  - master
+
+environment:
+  nodejs_version: '5.4.1'
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install
+
+build: off
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
+
+test_script:
+  - node --version
+  - npm --version
+  - set BABEL_DISABLE_CACHE=1
+  - set NODE_ENV=TEST
+  - node node_modules\mocha\bin\mocha

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "license": "MIT",
   "main": "lib/plugin.js",
   "scripts": {
+    "prebuild": "rimraf lib",
     "build": "babel src --out-dir lib",
-    "clean": "rimraf lib",
-    "example-clean": "rimraf build",
-    "example-build": "npm run example-clean && NODE_ENV=EXAMPLES_LIB babel examples/myCoolLibrary --out-dir build/myCoolLibrary",
+    "preexample-build": "rimraf build",
+    "example-build": "NODE_ENV=EXAMPLES_LIB babel examples/myCoolLibrary --out-dir build/myCoolLibrary",
     "example-run": "NODE_ENV=EXAMPLES_RUN babel-node ./examples/runExample/run.js",
     "lint": "eslint src test examples",
-    "prepublish": "npm run lint && npm run clean && npm run build",
+    "prepublish": "npm run lint && npm run build",
     "test": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha"
   },
   "repository": {

--- a/test/runtime.spec.js
+++ b/test/runtime.spec.js
@@ -4,22 +4,22 @@ import expect from 'expect';
 describe('runtime test', () => {
   it('css-modules loader should work', () => {
     const css = require('./assets/withoutExtractText/style.css');
-    expect(css).toEqual({ item: 'style__item--114y2', main: 'style__main--FyeeK' });
+    expect(css).toEqual({ item: 'style__item', main: 'style__main' });
   });
 
   it('css-modules + sass loaders should work', () => {
     const css = require('./assets/withoutExtractText/style.sass');
-    expect(css).toEqual({ item: 'style__item--3xWFz', main: 'style__main--2G5AL' });
+    expect(css).toEqual({ item: 'style__item', main: 'style__main' });
   });
 
   it('css-modules loader with ExtractText plugin should work', () => {
     const css = require('./assets/withExtractText/style.css');
-    expect(css).toEqual({ itemET: 'style__itemET--2RhIj', mainET: 'style__mainET--351DK' });
+    expect(css).toEqual({ itemET: 'style__itemET', mainET: 'style__mainET' });
   });
 
   it('css-modules + sass loader with ExtractText plugin should work', () => {
     const css = require('./assets/withExtractText/style.sass');
-    expect(css).toEqual({ itemET: 'style__itemET--tSpra', mainET: 'style__mainET--1ov5K' });
+    expect(css).toEqual({ itemET: 'style__itemET', mainET: 'style__mainET' });
   });
 
   it('file loader should work', () => {

--- a/test/runtime.webpack.config.js
+++ b/test/runtime.webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
         test: /\.css$/,
         loaders: [
           'style-loader',
-          'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]--[hash:base64:5]',
+          'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]',
           'postcss-loader',
         ],
         include: [
@@ -30,7 +30,7 @@ module.exports = {
         test: /\.sass$/,
         loaders: [
           'style-loader',
-          'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]--[hash:base64:5]',
+          'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]',
           'postcss-loader',
           `sass-loader?precision=10&indentedSyntax=sass`,
         ],
@@ -43,7 +43,7 @@ module.exports = {
         loader: ExtractTextPlugin.extract(
           'style-loader',
           [
-            'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]--[hash:base64:5]',
+            'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]',
             'postcss-loader',
           ]
         ),
@@ -57,7 +57,7 @@ module.exports = {
         loader: ExtractTextPlugin.extract(
           'style-loader',
           [
-            'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]--[hash:base64:5]',
+            'css-loader?modules&importLoaders=2&localIdentName=[name]__[local]',
             'postcss-loader',
             `sass-loader?precision=10&indentedSyntax=sass`,
           ]


### PR DESCRIPTION
I had to change classnames generation pattern. It probably includes file path into a hash, which is different under win (backslashes). So tests were failing: https://ci.appveyor.com/project/nkbt/babel-plugin-webpack-loaders/build/4

With current setup everything seems to work pretty perfect (build/lint is done as part of npm install, son only tests are added to config)