### PR TITLE
Switch to enhanced-resolve for webpack options

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015"],
+  "presets": ["es2015", "stage-0"],
   "env": {
     "EXAMPLES_LIB": {
       "plugins": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,33 +1,12 @@
 {
-  "extends": "eslint-config-airbnb",
+  "extends": "airbnb",
+  "parser": "babel-eslint",
   "env": {
     "browser": true,
     "mocha": true,
     "node": true
   },
-  "globals": {
-    "__DEV__": false,
-    "__DEV_TOOLS__": false,
-    "ReactElement": false,
-    "ReactComponent": false,
-  },
   "rules": {
-    "max-len": [1, 100, 2],
-    "id-length": 0,
-    "react/no-multi-comp": 0,
-    "react/jsx-uses-react": 2,
-    "react/jsx-uses-vars": 2,
-    "react/react-in-jsx-scope": 2,
-    "babel/generator-star-spacing": 1,
-    "babel/new-cap": 1,
-    "babel/object-shorthand": 1,
-    "babel/arrow-parens": 1,
-    "babel/no-await-in-loop": 1,
-    "block-scoped-var": 0,
-    "padded-blocks": 0
-  },
-  "plugins": [
-    "react",
-    "babel"
-  ]
+    "no-nested-ternary": 0
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
   ],
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.4.3",
     "babel-traverse": "^6.3.26",
     "babel-types": "^6.3.24",
     "babylon": "^6.3.26",
     "colors": "^1.1.2",
-    "resolve": "^1.1.6",
+    "enhanced-resolve": "^2.2.2",
     "rimraf": "^2.5.0",
     "shell-quote": "^1.4.3",
     "webpack": "^1.12.9"

--- a/test/runtime.spec.js
+++ b/test/runtime.spec.js
@@ -43,4 +43,9 @@ describe('runtime test', () => {
     const text = require('normalize.css/normalize.css');
     expect(text).toEqual(undefined);
   });
+
+  it('resolve.modules from webpack config should work', () => {
+    const text = require('assets/file.txt');
+    expect(text).toEqual('file.txt');
+  });
 });

--- a/test/runtime.webpack.config.js
+++ b/test/runtime.webpack.config.js
@@ -13,6 +13,12 @@ module.exports = {
   postcss: [
     autoprefixer({ browsers: ['last 2 versions'] }),
   ],
+  resolve: {
+    modules: [
+      __dirname,
+      'node_modules',
+    ],
+  },
   module: {
     loaders: [
       {


### PR DESCRIPTION
This uses the configuration in the resolve key of the webpack config to resolve file paths, enabling the use of the webpack 2 [`resolve.modules`](https://gist.github.com/sokra/27b24881210b56bbaff7#resolving-options) option.

Closes #4 