### PR TITLE
`require` or `import` returns path instead of file contents

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -197,7 +197,8 @@ export default function ({ types: t }) {
               : `./${p}`
           )(relative(dirname(filenameAbs), fileAbsPath));
 
-          path.replaceWith(t.stringLiteral(relPath));
+          // path.replaceWith(t.stringLiteral(relPath));
+          path.get('arguments.0').replaceWith(t.stringLiteral(relPath));
           return;
         }
 

--- a/test/deepTree/deep.spec.js
+++ b/test/deepTree/deep.spec.js
@@ -8,5 +8,6 @@ describe('deep test', () => {
 
   it('must resolve js files in resolve modules', () => {
     const emptyJs = require('empty'); // eslint-disable-line
+    expect(emptyJs.emptyFn).toEqual(() => {});
   });
 });

--- a/test/deepTree/deep.spec.js
+++ b/test/deepTree/deep.spec.js
@@ -1,13 +1,19 @@
 import expect from 'expect';
 
+import emptyJs from 'empty';
+
 describe('deep test', () => {
   it('css-modules loader should work with ..', () => {
     const css = require('../assets/withoutExtractText/style.css');
     expect(css).toEqual({ item: 'style__item', main: 'style__main' });
   });
 
-  it('must resolve js files in resolve modules', () => {
-    const emptyJs = require('empty'); // eslint-disable-line
-    expect(emptyJs.emptyFn).toEqual(() => {});
+  it('must resolve import js files in resolve modules', () => {
+    expect(emptyJs).toEqual(1000);
+  });
+
+  it('must resolve require js files in resolve modules', () => {
+    const emptyR = require('empty');
+    expect(emptyR.default).toEqual(1000);
   });
 });

--- a/test/resolveDir/empty.js
+++ b/test/resolveDir/empty.js
@@ -1,3 +1,2 @@
-export default {
-  emptyFn: () => {},
-};
+const value = 1000;
+export default value;

--- a/test/resolveDir/empty.js
+++ b/test/resolveDir/empty.js
@@ -1,0 +1,3 @@
+export default {
+  emptyFn: () => {},
+};


### PR DESCRIPTION
Oops, looks like the changes from #27 are returning a path instead of file contents.

For instance, if I log out the following, it prints a path to the file (string):

```js
import emptyJs from 'empty';
console.log('emptyJs', typeof emptyJs, emptyJs);
// emptyJs string ../resolveDir/empty.js
```

Here's a failing test.

Ref #26 #27 
