### PR TITLE
Add Webpack 2 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -28,6 +28,17 @@
         ]
       ]
     },
+    "TEST_2": {
+      "plugins": [
+        [
+          "./lib/plugin.js",
+          {
+            "config": "./test/runtime.webpack2.config.js",
+            "verbose": false
+          }
+        ]
+      ]
+    },
     "AVA_TEST": {
       "plugins": [
         [

--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,7 @@
           "./lib/plugin.js",
           {
             "config": "./examples_webpack_configs/run.webpack.config.js",
-            "verbose": false,
+            "verbose": false
           }
         ]
       ]
@@ -23,7 +23,7 @@
           "./lib/plugin.js",
           {
             "config": "./test/runtime.webpack.config.js",
-            "verbose": false,
+            "verbose": false
           }
         ]
       ]
@@ -34,7 +34,7 @@
           "./lib/plugin.js",
           {
             "config": "${CONFIG}",
-            "verbose": false,
+            "verbose": false
           }
         ]
       ]
@@ -45,7 +45,7 @@
           "./lib/plugin.js",
           {
             "config": "./test/runtime.webpack.config.babel.js",
-            "verbose": false,
+            "verbose": false
           }
         ]
       ]
@@ -56,7 +56,7 @@
           "./lib/plugin.js",
           {
             "config": "${CONFIG}",
-            "verbose": false,
+            "verbose": false
           }
         ]
       ]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "example-run": "BABEL_DISABLE_CACHE=1 NODE_ENV=EXAMPLES_RUN babel-node ./examples/runExample/run.js",
     "lint": "eslint src test examples",
     "prepublish": "npm run lint && npm run build",
-    "main-test": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha './test/**/*.spec.js'",
+    "test-webpack-1": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha './test/**/*.spec.js'",
+    "test-webpack-2": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST_2 mocha './test/**/*.spec2.js'",
+    "main-test": "npm run test-webpack-1 && npm run test-webpack-2",
     "babel-config-test": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST_BABEL mocha './test/**/*.spec.babel.js'",
     "dynamic-config-test": "CONFIG=$(pwd)/test/runtime.webpack.config.js BABEL_DISABLE_CACHE=1 NODE_ENV=DYNAMIC_CONFIG_TEST mocha './test/**/*.spec.js'",
     "warn-test": "BABEL_DISABLE_CACHE=1 mocha './test/**/*.warn.js'",
@@ -42,8 +44,7 @@
     "enhanced-resolve": "^2.2.2",
     "lodash": "^4.6.1",
     "rimraf": "^2.5.0",
-    "shell-quote": "^1.4.3",
-    "webpack": "^1.12.9"
+    "shell-quote": "^1.4.3"
   },
   "devDependencies": {
     "autoprefixer": "^6.2.3",
@@ -70,7 +71,11 @@
     "sass-loader": "^3.1.2",
     "sinon": "^1.17.3",
     "style-loader": "^0.13.0",
-    "url-loader": "^0.5.7"
+    "url-loader": "^0.5.7",
+    "webpack": "^2.1.0-beta.7"
+  },
+  "peerDependencies": {
+    "webpack": ">=1.12.9 <3.0.0"
   },
   "ava": {
     "files": [

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -193,9 +193,13 @@ export default function ({ types: t }) {
 
         // support env var interpolation into configPath
         const compiledConfigPath = template(configPath)(process.env);
-        const config = compiledConfigPath === configPath
+        let config = compiledConfigPath === configPath
            ? localInteropRequire(resolve(process.cwd(), compiledConfigPath))
            : localInteropRequire(resolve(compiledConfigPath));
+
+        if (typeof config === 'function') {
+          config = config();
+        }
 
         if (Object.keys(config).length === 0) {
           // it's possible require calls inside webpack config or bad config

--- a/test/ava/index.js
+++ b/test/ava/index.js
@@ -2,5 +2,5 @@ import test from 'ava';
 import css from '../assets/withoutExtractText/style.css';
 
 test(t => {
-  t.same(css, { item: 'style__item', main: 'style__main' });
+  t.deepEqual(css, { item: 'style__item', main: 'style__main' });
 });

--- a/test/runtime.spec2.js
+++ b/test/runtime.spec2.js
@@ -1,0 +1,9 @@
+// test/runtime.webpack2.config.js is used and defined at .babelrc:/env/TEST2/plugins
+import expect from 'expect';
+
+describe('runtime test with webpack@2', () => {
+  it('file-loader should work', () => {
+    const text = require('./assets/file.txt');
+    expect(text).toEqual('file.txt');
+  });
+});

--- a/test/runtime.webpack2.config.js
+++ b/test/runtime.webpack2.config.js
@@ -1,0 +1,16 @@
+module.exports = function config() {
+  return {
+    output: {
+      // YOU NEED TO SET libraryTarget: 'commonjs2'
+      libraryTarget: 'commonjs2',
+    },
+    module: {
+      loaders: [
+        {
+          test: /\.txt$/,
+          loaders: ['file-loader?name=[name].[ext]'],
+        },
+      ],
+    },
+  };
+};


### PR DESCRIPTION
Noticeable changes:
- webpack function can be a function (that will generate a classic config)
- webpack is not a dependency anymore, just a peer dep (so you can choose webpack version).

This PR also include 2 simple commits related to AVA and babelrc config.

This will closes #88 