### PR TITLE
Fix ava "Test should have a title" lint issue

### DIFF
--- a/test/ava/index.js
+++ b/test/ava/index.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import css from '../assets/withoutExtractText/style.css';
 
-test(t => {
+test('ava withoutExtractText test', t => {
   t.deepEqual(css, { item: 'style__item', main: 'style__main' });
 });


### PR DESCRIPTION
```
.../node_modules/babel-plugin-webpack-loaders/test/ava/index.js
  4:1  error  Test should have a title  ava/test-title

✖ 1 problem (1 error, 0 warnings)
```