### PR TITLE
fix "Cannot find module" on Windows 10 #106

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "colors": "^1.1.2",
     "enhanced-resolve": "^2.2.2",
     "lodash": "^4.6.1",
-    "rimraf": "^2.5.0",
-    "shell-quote": "^1.4.3"
+    "rimraf": "^2.5.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.2.3",

--- a/src/runWebPackSync.js
+++ b/src/runWebPackSync.js
@@ -3,7 +3,6 @@ import { readFileSync } from 'fs';
 import rimraf from 'rimraf';
 import colors from 'colors/safe';
 import { tmpdir } from 'os';
-import { quote } from 'shell-quote';
 import { execSync } from 'child_process';
 
 export default ({ path, configPath, config, verbose }) => {
@@ -18,14 +17,13 @@ export default ({ path, configPath, config, verbose }) => {
 
   // I need to run webpack via execSync because I have not found the way how to run
   // babel visitors asynchronously or run webpack compile synchronously
-  const webPackStdOut = execSync(
-    quote([
-      'node', // for windows support
-      webPackPath,
-      path, outPath,
-      '--config', configPath,
-      '--bail',
-    ])
+  const webPackStdOut = execSync([
+    'node', // for windows support
+    webPackPath,
+    path, outPath,
+    '--config', configPath,
+    '--bail',
+  ].join(' ')
   );
 
   if (verbose) {


### PR DESCRIPTION
fix for #106 removing dependency shell-quote as it was causing issues in windows finding module