### PR TITLE
Support webpack 2.1.0-beta as a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "webpack": "2.1.0-beta.20"
   },
   "peerDependencies": {
-    "webpack": ">=1.12.9 <3.0.0"
+    "webpack": ">=1.12.9 <3.0.0 || ^2.1.0-beta.0"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
The range ">=1.12.9 <3.0.0" does not include any beta versions. With webpack@2 currently in beta, it needs to be explicitly allowed to prevent a missing peer warning when using webpack@2:

> npm WARN babel-plugin-webpack-loaders@0.8.0 requires a peer of webpack@>=1.12.9 <3.0.0 but none was installed.

The warning does not stop npm install with npm@4, it does prevent shrinkwrap from running.