### PR TITLE
Fix webpack2 loaders

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -255,7 +255,9 @@ More information at issue #36`
           return;
         }
 
-        if (config.module.loaders.some((l) => l.test.test(filePath) || l.test.test(fileAbsPath))) {
+        const wpLoaders = config.module.loaders || config.module.rules;
+
+        if (wpLoaders.some((l) => l.test.test(filePath) || l.test.test(fileAbsPath))) {
           if (isJSFile(fileAbsPath) && skipJs) {
             // js and jsx files in loaders is unsupported by webpack-loader plugin.
             // all babel settings in loader will be skipped`


### PR DESCRIPTION
In webpack2 release loaders have been renamed to rules.