### PR TITLE
fix: update to @dabh/colors for security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-traverse": "^6.3.26",
     "babel-types": "^6.3.24",
     "babylon": "^6.3.26",
-    "colors": "^1.1.2",
+    "@dabh/colors": "^1.4.0",
     "enhanced-resolve": "^2.2.2",
     "lodash": "^4.6.1",
     "rimraf": "^2.5.0"


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR updates the color package to using [@dabh/colors](https://www.npmjs.com/package/@dabh/colors) as stated on this [colors issue #317](https://github.com/Marak/colors.js/issues/317#issue-1098535594) which is a safe alternative.

cc: @istarkov 